### PR TITLE
Add close function that allows for cleaning closing tls connection

### DIFF
--- a/imports.md
+++ b/imports.md
@@ -437,6 +437,9 @@ is ready for reading, before performing the <code>splice</code>.</p>
 #### <a id="pollable"></a>`type pollable`
 [`pollable`](#pollable)
 <p>
+#### <a id="io_error"></a>`type io-error`
+[`error`](#error)
+<p>
 #### <a id="client_handshake"></a>`resource client-handshake`
 <h4><a id="client_connection"></a><code>resource client-connection</code></h4>
 <h4><a id="future_client_streams"></a><code>resource future-client-streams</code></h4>
@@ -461,6 +464,15 @@ is ready for reading, before performing the <code>splice</code>.</p>
 <h5>Return values</h5>
 <ul>
 <li><a id="static_client_handshake_finish.0"></a> own&lt;<a href="#future_client_streams"><a href="#future_client_streams"><code>future-client-streams</code></a></a>&gt;</li>
+</ul>
+<h4><a id="method_client_connection_close_notify"></a><code>[method]client-connection.close-notify: func</code></h4>
+<h5>Params</h5>
+<ul>
+<li><a id="method_client_connection_close_notify.self"></a><code>self</code>: borrow&lt;<a href="#client_connection"><a href="#client_connection"><code>client-connection</code></a></a>&gt;</li>
+</ul>
+<h5>Return values</h5>
+<ul>
+<li><a id="method_client_connection_close_notify.0"></a> option&lt;result&lt;_, own&lt;<a href="#io_error"><a href="#io_error"><code>io-error</code></a></a>&gt;&gt;&gt;</li>
 </ul>
 <h4><a id="method_future_client_streams_subscribe"></a><code>[method]future-client-streams.subscribe: func</code></h4>
 <h5>Params</h5>

--- a/imports.md
+++ b/imports.md
@@ -437,9 +437,6 @@ is ready for reading, before performing the <code>splice</code>.</p>
 #### <a id="pollable"></a>`type pollable`
 [`pollable`](#pollable)
 <p>
-#### <a id="io_error"></a>`type io-error`
-[`error`](#error)
-<p>
 #### <a id="client_handshake"></a>`resource client-handshake`
 <h4><a id="client_connection"></a><code>resource client-connection</code></h4>
 <h4><a id="future_client_streams"></a><code>resource future-client-streams</code></h4>
@@ -465,14 +462,10 @@ is ready for reading, before performing the <code>splice</code>.</p>
 <ul>
 <li><a id="static_client_handshake_finish.0"></a> own&lt;<a href="#future_client_streams"><a href="#future_client_streams"><code>future-client-streams</code></a></a>&gt;</li>
 </ul>
-<h4><a id="method_client_connection_close_notify"></a><code>[method]client-connection.close-notify: func</code></h4>
+<h4><a id="method_client_connection_close_output"></a><code>[method]client-connection.close-output: func</code></h4>
 <h5>Params</h5>
 <ul>
-<li><a id="method_client_connection_close_notify.self"></a><code>self</code>: borrow&lt;<a href="#client_connection"><a href="#client_connection"><code>client-connection</code></a></a>&gt;</li>
-</ul>
-<h5>Return values</h5>
-<ul>
-<li><a id="method_client_connection_close_notify.0"></a> option&lt;result&lt;_, own&lt;<a href="#io_error"><a href="#io_error"><code>io-error</code></a></a>&gt;&gt;&gt;</li>
+<li><a id="method_client_connection_close_output.self"></a><code>self</code>: borrow&lt;<a href="#client_connection"><a href="#client_connection"><code>client-connection</code></a></a>&gt;</li>
 </ul>
 <h4><a id="method_future_client_streams_subscribe"></a><code>[method]future-client-streams.subscribe: func</code></h4>
 <h5>Params</h5>

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -4,6 +4,8 @@ interface types {
     use wasi:io/streams@0.2.3.{input-stream, output-stream};
     @unstable(feature = tls)
     use wasi:io/poll@0.2.3.{pollable};
+    @unstable(feature = tls)
+    use wasi:io/error@0.2.3.{error as io-error};
 
     @unstable(feature = tls)
     resource client-handshake {
@@ -16,6 +18,8 @@ interface types {
 
     @unstable(feature = tls)
     resource client-connection {
+        @unstable(feature = tls)
+        close-notify: func() -> option<result<_, io-error>>;
     }
 
     @unstable(feature = tls)

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -4,8 +4,6 @@ interface types {
     use wasi:io/streams@0.2.3.{input-stream, output-stream};
     @unstable(feature = tls)
     use wasi:io/poll@0.2.3.{pollable};
-    @unstable(feature = tls)
-    use wasi:io/error@0.2.3.{error as io-error};
 
     @unstable(feature = tls)
     resource client-handshake {
@@ -19,7 +17,7 @@ interface types {
     @unstable(feature = tls)
     resource client-connection {
         @unstable(feature = tls)
-        close-notify: func() -> option<result<_, io-error>>;
+        close-output: func();
     }
 
     @unstable(feature = tls)


### PR DESCRIPTION
When adding a "read to end of stream" type test.  Needed a way to close the tls connection in a clean manner.  