### PR TITLE
Expose handshake error

### DIFF
--- a/imports.md
+++ b/imports.md
@@ -437,6 +437,9 @@ is ready for reading, before performing the <code>splice</code>.</p>
 #### <a id="pollable"></a>`type pollable`
 [`pollable`](#pollable)
 <p>
+#### <a id="io_error"></a>`type io-error`
+[`error`](#error)
+<p>
 #### <a id="client_handshake"></a>`resource client-handshake`
 <h4><a id="client_connection"></a><code>resource client-connection</code></h4>
 <h4><a id="future_client_streams"></a><code>resource future-client-streams</code></h4>
@@ -483,5 +486,5 @@ is ready for reading, before performing the <code>splice</code>.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a id="method_future_client_streams_get.0"></a> option&lt;result&lt;result&lt;(own&lt;<a href="#client_connection"><a href="#client_connection"><code>client-connection</code></a></a>&gt;, own&lt;<a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a>&gt;, own&lt;<a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a>&gt;)&gt;&gt;&gt;</li>
+<li><a id="method_future_client_streams_get.0"></a> option&lt;result&lt;result&lt;(own&lt;<a href="#client_connection"><a href="#client_connection"><code>client-connection</code></a></a>&gt;, own&lt;<a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a>&gt;, own&lt;<a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a>&gt;), own&lt;<a href="#io_error"><a href="#io_error"><code>io-error</code></a></a>&gt;&gt;&gt;&gt;</li>
 </ul>

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -4,6 +4,8 @@ interface types {
     use wasi:io/streams@0.2.3.{input-stream, output-stream};
     @unstable(feature = tls)
     use wasi:io/poll@0.2.3.{pollable};
+    @unstable(feature = tls)
+    use wasi:io/error@0.2.3.{error as io-error};
 
     @unstable(feature = tls)
     resource client-handshake {
@@ -26,6 +28,6 @@ interface types {
         subscribe: func() -> pollable;
 
         @unstable(feature = tls)
-        get: func() -> option<result<result<tuple<client-connection, input-stream, output-stream>>>>;
+        get: func() -> option<result<result<tuple<client-connection, input-stream, output-stream>, io-error>>>;
     }
 }


### PR DESCRIPTION
This updates `client-handshake/get` to return a `wasi:io/error` on failure.

There are two sources for errors during the handshake:
- The underlying transport; the stream pair passed into the `client-handshake` constructor produced an error. In that case, the handshake object passes that error on to the consumer as-is. E.g. assuming the TLS stream wraps an TCP stream, it is possible to call `wasi:sockets/network/network-error-code` on an IO error returned from the TLS handshake.
- The TLS implementation itself. E.g. certificate expired, TLS version mismatch, etc. For now, the message accessible through `wasi:io/error/to-debug-string` is the _only_ way for a guest to know what went wrong. We could add a `tls-error-code` method in the future similar to wasi-sockets, wasi-filesystem & wasi-http if the need ever arises to downcast into a structured variant.

Relates to:
- https://github.com/bytecodealliance/wasmtime/issues/10369
- https://github.com/WebAssembly/wasi-tls/issues/9