### PR TITLE
feat(p3): add `client` interface

### DIFF
--- a/wit-0.3.0-draft/client.wit
+++ b/wit-0.3.0-draft/client.wit
@@ -1,4 +1,6 @@
 interface client {
+    use types.{error};
+
     resource connector {
         constructor();
 
@@ -15,6 +17,6 @@ interface client {
 
         /// Perform the handshake.
         /// The `send` & `receive` streams must be set up before calling this method.
-        connect: async func(this: connector, server-name: string) -> result<_, error>;
+        connect: static async func(this: connector, server-name: string) -> result<_, error>;
     }
 }

--- a/wit-0.3.0-draft/client.wit
+++ b/wit-0.3.0-draft/client.wit
@@ -1,36 +1,20 @@
 interface client {
-    resource hello {
-        /// Constructs a new ClientHello message.
+    resource connector {
         constructor();
 
-        /// Sets the server name indicator.
-        ///
-        /// Returns an error if it is not valid.
-        ///
-        /// If this function is not called, the SNI extension will not be sent.
-        set-server-name: func(server-name: string) -> result;
+        /// Set up the encryption stream transform.
+        /// This takes an unprotected `cleartext` application data stream and
+        /// returns an encrypted data stream, ready to be sent out over the network.
+        /// Closing the `cleartext` stream will cause a `close_notify` packet to be emitted on the returned output stream.
+        send: func(cleartext: stream<u8>) -> tuple<stream<u8>, future<result<_, error>>>;
 
-        /// Sets the ALPN IDs advertised by the client.
-        set-alpn-ids: func(alpn-ids: list<list<u8>>);
+        /// Set up the decryption stream transform.
+        /// This takes an encrypted data stream, as received via e.g. the network,
+        /// and returns a decrypted application data stream.
+        receive: func(ciphertext: stream<u8>) -> tuple<stream<u8>, future<result<_, error>>>;
 
-        /// Sets a list of the symmetric cipher options supported by
-        /// the client, specifically the record protection algorithm
-        /// (including secret key length) and a hash to be used with HKDF, in
-        /// descending order of client preference.
-        ///
-        /// If this list is empty, the implementation must use a reasonable default.
-        set-cipher-suites: func(cipher-suites: list<u16>);
+        /// Perform the handshake.
+        /// The `send` & `receive` streams must be set up before calling this method.
+        connect: async func(this: connector, server-name: string) -> result<_, error>;
     }
-
-    resource handshake {
-        /// Gets the single cipher suite selected by the server from
-        /// the list in ClientHello.cipher_suites.
-        get-cipher-suite: func() -> u16;
-
-        /// Closing the `data` stream will trigger `close_notify`.
-        finish: static func(this: handshake, data: stream<u8>) -> tuple<stream<u8>, future<result>>;
-    }
-
-    /// Initiate the client TLS handshake
-    connect: func(hello: hello, incoming: stream<u8>) -> tuple<stream<u8>, future<result<handshake>>>;
 }

--- a/wit-0.3.0-draft/client.wit
+++ b/wit-0.3.0-draft/client.wit
@@ -1,0 +1,36 @@
+interface client {
+    resource hello {
+        /// Constructs a new ClientHello message.
+        constructor();
+
+        /// Sets the server name indicator.
+        ///
+        /// Returns an error if it is not valid.
+        ///
+        /// If this function is not called, the SNI extension will not be sent.
+        set-server-name: func(server-name: string) -> result;
+
+        /// Sets the ALPN IDs advertised by the client.
+        set-alpn-ids: func(alpn-ids: list<list<u8>>);
+
+        /// Sets a list of the symmetric cipher options supported by
+        /// the client, specifically the record protection algorithm
+        /// (including secret key length) and a hash to be used with HKDF, in
+        /// descending order of client preference.
+        ///
+        /// If this list is empty, the implementation must use a reasonable default.
+        set-cipher-suites: func(cipher-suites: list<u16>);
+    }
+
+    resource handshake {
+        /// Gets the single cipher suite selected by the server from
+        /// the list in ClientHello.cipher_suites.
+        get-cipher-suite: func() -> u16;
+
+        /// Closing the `data` stream will trigger `close_notify`.
+        finish: static func(this: handshake, data: stream<u8>) -> tuple<stream<u8>, future<result>>;
+    }
+
+    /// Initiate the client TLS handshake
+    connect: func(hello: hello, incoming: stream<u8>) -> tuple<stream<u8>, future<result<handshake>>>;
+}

--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -1,0 +1,5 @@
+interface types {
+    resource error {
+        to-debug-string: func() -> string;
+    }
+}

--- a/wit-0.3.0-draft/world.wit
+++ b/wit-0.3.0-draft/world.wit
@@ -1,0 +1,5 @@
+package wasi:tls@0.3.0-draft;
+
+world imports {
+    import client;
+}

--- a/wit-0.3.0-draft/world.wit
+++ b/wit-0.3.0-draft/world.wit
@@ -2,4 +2,5 @@ package wasi:tls@0.3.0-draft;
 
 world imports {
     import client;
+    import types;
 }


### PR DESCRIPTION
Introduce the `client` interface designed for wasip3, which is at feature-parity with what's currently available in `main` for wasip2 with a few additions

https://github.com/bytecodealliance/wasmtime/pull/12174 contains mostly-complete host implementation of the interface in the proposed shape with a passing test (adapted directly from existing wasip2 test). The interface in the PR is an in-progress *superset* of the interface proposed in this PR.

This is by no means complete and is intended to just be the first step with more PRs to follow as I validate the design by continuing the host implementation in Wasmtime as well as a Python guest implementation utilizing these (have not started on Python work yet)

refs https://github.com/WebAssembly/wasi-sockets/issues/100
refs https://github.com/WebAssembly/wasi-sockets/pull/104